### PR TITLE
fix doc of `HipStr::borrowed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Notable changes only.
 
+## [unreleased]
+
+### Fixed
+
+- fix doc issue [#28](https://github.com/polazarus/hipstr/issues/28)
+
 ## [0.5.1] - 2024-08-02
 
 ### Added
@@ -110,7 +116,7 @@ Most of those addition are breaking because they shadows `str`'s methods.
 
 Initial release
 
-<!-- [unreleased]: https://github.com/polazarus/hipstr/compare/0.5.1...HEAD -->
+[unreleased]: https://github.com/polazarus/hipstr/compare/0.5.1...HEAD
 [0.5.1]: https://github.com/polazarus/hipstr/compare/0.5.0...0.5.1
 [0.5.0]: https://github.com/polazarus/hipstr/compare/0.4.0...0.5.0
 [0.4.0]: https://github.com/polazarus/hipstr/compare/0.3.3...0.4.0

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -128,7 +128,9 @@ where
         Self(Raw::with_capacity(cap))
     }
 
-    /// Creates a new `HipByt` from a borrowed slice without copying the slice.
+    /// Creates a new `HipByt` from a byte slice.
+    /// No heap allocation is performed.
+    /// **The slice is not copied.**
     ///
     /// # Examples
     ///

--- a/src/string.rs
+++ b/src/string.rs
@@ -116,7 +116,9 @@ where
         Self(HipByt::with_capacity(cap))
     }
 
-    /// Creates a new `HipStr` from a static string slice without copying the slice.
+    /// Creates a new `HipStr` from a string slice.
+    /// No heap allocation is performed.
+    /// **The string is not copied.**
     ///
     /// # Examples
     ///


### PR DESCRIPTION
fixes #28