### PR TITLE
fix MIRI analysis

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,8 @@
     "cSpell.words": [
         "alloc",
         "arcstr",
+        "bstr",
+        "bstring",
         "clippy",
         "clonable",
         "codecov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes only.
 ### Fixed
 
 - fix doc issue [#28](https://github.com/polazarus/hipstr/issues/28)
+- fix MIRI check due to provenance [#32](https://github.com/polazarus/hipstr/pull/32)
 
 ## [0.5.1] - 2024-08-02
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ serde = { version = "1.0.69", optional = true, default-features = false, feature
 serde_bytes = { version = "0.11.5", optional = true, default-features = false, features = [
     "alloc",
 ] }
+sptr = "0.3.2"
 
 [workspace]
 members = ['string-comparison']

--- a/src/backend/rc.rs
+++ b/src/backend/rc.rs
@@ -86,7 +86,7 @@ impl Count for ThreadSafe {
 }
 
 /// Reference counting inner cell.
-struct Inner<T, C> {
+pub struct Inner<T, C> {
     count: C,
     value: T,
 }
@@ -100,6 +100,7 @@ struct Inner<T, C> {
 ///   stack copies) without `incr()`-ing it
 /// - it should not be dropped (except for temporary copies) without
 ///   `decr()`-ing it
+#[repr(transparent)]
 pub struct Raw<T, C>(NonNull<Inner<T, C>>);
 
 impl<T, C> Copy for Raw<T, C> {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,7 @@
 //! * `unstable`: exposes internal `Backend` trait that may change at any moment
 
 #![cfg_attr(miri, feature(strict_provenance))]
+#![cfg_attr(miri, feature(exposed_provenance))]
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(clippy::pedantic, clippy::nursery, clippy::cargo)]


### PR DESCRIPTION
using exposed provenance

temporarily add sptr, waiting on rust-lang/rust#130350