### PR TITLE
perf: avoid extra string allocation in deserialize

### DIFF
--- a/src/string/serde.rs
+++ b/src/string/serde.rs
@@ -40,6 +40,14 @@ impl<'a, 'b, B: Backend> Visitor<'a> for HipStrVisitor<'b, B> {
     {
         Ok(HipStr::from(v))
     }
+
+    #[inline]
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Ok(HipStr::from(v))
+    }
 }
 
 impl<'de, B> Deserialize<'de> for HipStr<'_, B>


### PR DESCRIPTION
This runs slightly faster for me because it avoids the `String::deserialize`.

https://github.com/typst/ecow/blob/e64b6d23aa5c92d10a48ebb9fbec5762e5c3d21e/src/string.rs#L530-L564