### PR TITLE
fix: compile when targeting Wasm

### DIFF
--- a/src/os_string.rs
+++ b/src/os_string.rs
@@ -15,7 +15,8 @@ use crate::Backend;
 mod cmp;
 mod convert;
 
-#[cfg(feature = "serde")]
+// OsStr(ing) implements Serialize/Deserialize only on Unix and Windows. thx @dsherret
+#[cfg(all(feature = "serde", any(unix, windows)))]
 mod serde;
 
 #[cfg(test)]

--- a/src/os_string/serde.rs
+++ b/src/os_string/serde.rs
@@ -5,7 +5,6 @@ use serde::{Deserialize, Serialize};
 use super::HipOsStr;
 use crate::Backend;
 
-#[cfg(all(feature = "std", any(unix, windows)))]
 impl<B> Serialize for HipOsStr<'_, B>
 where
     B: Backend,
@@ -19,7 +18,6 @@ where
     }
 }
 
-#[cfg(all(feature = "std", any(unix, windows)))]
 impl<'de, B> Deserialize<'de> for HipOsStr<'_, B>
 where
     B: Backend,
@@ -54,7 +52,7 @@ mod tests {
                 Token::SeqEnd,
             ],
         );
-        #[cfg(not(windows))]
+        #[cfg(unix)]
         assert_tokens(
             &empty,
             &[

--- a/src/os_string/serde.rs
+++ b/src/os_string/serde.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use super::HipOsStr;
 use crate::Backend;
 
+#[cfg(all(feature = "std", any(unix, windows)))]
 impl<B> Serialize for HipOsStr<'_, B>
 where
     B: Backend,
@@ -18,6 +19,7 @@ where
     }
 }
 
+#[cfg(all(feature = "std", any(unix, windows)))]
 impl<'de, B> Deserialize<'de> for HipOsStr<'_, B>
 where
     B: Backend,


### PR DESCRIPTION
```
error[E0599]: the method `serialize` exists for reference `&OsStr`, but its trait bounds were not satisfied
  --> /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hipstr-0.6.0/src/os_string/serde.rs:17:26
   |
17 |         self.as_os_str().serialize(serializer)
   |                          ^^^^^^^^^ method cannot be called on `&OsStr` due to unsatisfied trait bounds
   |
   = note: the following trait bounds were not satisfied:
           `OsStr: serde::Serialize`
           which is required by `&OsStr: serde::Serialize`

error[E0599]: no function or associated item named `deserialize` found for struct `OsString` in the current scope
  --> /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hipstr-0.6.0/src/os_string/serde.rs:30:33
   |
30 |         Ok(Self::from(OsString::deserialize(deserializer)?))
   |                                 ^^^^^^^^^^^ function or associated item not found in `OsString`
   |
note: if you're trying to build a new `OsString` consider using one of the following associated functions:
      OsString::new
      OsString::from_encoded_bytes_unchecked
      OsString::with_capacity
  --> /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/ffi/os_str.rs:141:5
```